### PR TITLE
Fix xamarin.Android bindings path.

### DIFF
--- a/Xamarin.SamsungPass/SamsungPass/SamsungPass.csproj
+++ b/Xamarin.SamsungPass/SamsungPass/SamsungPass.csproj
@@ -68,7 +68,7 @@
     <TransformFile Include="Transforms\EnumMethods.xml" />
     <TransformFile Include="Transforms\Metadata.xml" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Novell\Xamarin.Android.Bindings.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <ItemGroup>
     <EmbeddedJar Include="Jars\empty.jar" />
   </ItemGroup>


### PR DESCRIPTION
@PhilippC can you confirm that this doesn't affect Windows builds? If it does, maybe we could workaround by using the [Condition attribute](https://msdn.microsoft.com/en-us/library/92x05xfs.aspx)?

See https://github.com/PhilippC/keepass2android/pull/156#issuecomment-415965219